### PR TITLE
Remove of usage of java 8 class

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,6 @@ ext {
 println "Host: " + java.net.InetAddress.getLocalHost()
 println "Gradle: " + gradle.gradleVersion + " JVM: " + org.gradle.internal.jvm.Jvm.current() + " Groovy: " + GroovySystem.getVersion()
 println "Build: group: '${project.group}', name: '${project.name}', version: '${project.version}'"
-println "Timestamp: " + java.time.Instant.now().atZone(java.time.ZoneId.systemDefault()).toString()
 
 apply plugin: 'java'
 apply plugin: 'maven'


### PR DESCRIPTION
Removed of usage of java 8 class, which fails gradle usage, since we have defined sourceCompatibility for 1.7
